### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ The Dashboard will be running at `http://localhost:4200/`. The browser will auto
 
 Use [https://github.com/tjunnone/npm-check-updates](https://github.com/tjunnone/npm-check-updates)
 
-[Angular]: http://angular.io/
+[Angular]: https://angular.io/
 [Angular CLI]: https://cli.angular.io/
 [frontend-maven-plugin]: https://github.com/eirslett/frontend-maven-plugin
 [Git]: https://git-scm.com/
-[Maven]: http://maven.apache.org/
-[Node.js]: http://nodejs.org/
+[Maven]: https://maven.apache.org/
+[Node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/
 [Protractor]: https://github.com/angular/protractor

--- a/ui/.editorconfig
+++ b/ui/.editorconfig
@@ -1,4 +1,4 @@
-# Editor configuration, see http://editorconfig.org
+# Editor configuration, see https://editorconfig.org
 root = true
 
 [*]

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist

--- a/ui/README.md
+++ b/ui/README.md
@@ -88,11 +88,11 @@ The Dashboard will be running at `http://localhost:4200/`. The browser will auto
 
 Use [https://github.com/tjunnone/npm-check-updates](https://github.com/tjunnone/npm-check-updates)
 
-[Angular]: http://angular.io/
+[Angular]: https://angular.io/
 [Angular CLI]: https://cli.angular.io/
 [frontend-maven-plugin]: https://github.com/eirslett/frontend-maven-plugin
 [Git]: https://git-scm.com/
-[Maven]: http://maven.apache.org/
-[Node.js]: http://nodejs.org/
+[Maven]: https://maven.apache.org/
+[Node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/
 [Protractor]: https://github.com/angular/protractor

--- a/ui/src/polyfills.ts
+++ b/ui/src/polyfills.ts
@@ -44,7 +44,7 @@ import 'core-js/es7/reflect';
 
 /**
  * Required to support Web Animations `@angular/animation`.
- * Needed for: All but Chrome, Firefox and Opera. http://caniuse.com/#feat=web-animation
+ * Needed for: All but Chrome, Firefox and Opera. https://caniuse.com/#feat=web-animation
  **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://angular.io/ with 2 occurrences migrated to:  
  https://angular.io/ ([https](https://angular.io/) result 200).
* [ ] http://caniuse.com/ with 1 occurrences migrated to:  
  https://caniuse.com/ ([https](https://caniuse.com/) result 200).
* [ ] http://editorconfig.org with 1 occurrences migrated to:  
  https://editorconfig.org ([https](https://editorconfig.org) result 200).
* [ ] http://maven.apache.org/ with 2 occurrences migrated to:  
  https://maven.apache.org/ ([https](https://maven.apache.org/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://help.github.com/ignore-files/ with 1 occurrences migrated to:  
  https://help.github.com/ignore-files/ ([https](https://help.github.com/ignore-files/) result 301).
* [ ] http://nodejs.org/ with 2 occurrences migrated to:  
  https://nodejs.org/ ([https](https://nodejs.org/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:4200/ with 3 occurrences
* http://localhost:7577/ with 1 occurrences
* http://localhost:9393/ with 4 occurrences